### PR TITLE
fix: Ignore strapping pin warning on TX GPIO

### DIFF
--- a/esphome/esp-daikin-ctrl.yaml
+++ b/esphome/esp-daikin-ctrl.yaml
@@ -44,7 +44,9 @@ climate:
     name: "Ducted AC"
 
     # P1P2/Homebus interface
-    rx_pin: 2        # RX from MAX22088
+    rx_pin:          # RX from MAX22088
+      number: 2
+      ignore_strapping_warning: true
     tx_pin: 3        # TX to MAX22088
     enable_pin: 10   # TX enable
 


### PR DESCRIPTION
 https://esphome.io/guides/faq/#why-am-i-getting-a-warning-about-strapping-pins
 
 Fixes https://github.com/gregdavill/daikin-esp/issues/9