### PR TITLE
ci: Use esphome github action and pin to 2026.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,21 +1,32 @@
-# This is a basic workflow to help you get started with Actions
-
 name: esphome-build
 
 on:
-  create: { }
-  push: { }
-  pull_request: { }
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  ESPHOME_VERSION: "2026.4.0"
+  ESPHOME_CONFIG: esphome/esp-daikin-ctrl.yaml
 
 jobs:
   build:
+    name: Build firmware
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Run esphome build
-        run: |
-          pip install esphome
-          esphome compile esphome/esp-daikin-ctrl.yaml
+      - name: Build firmware
+        id: esphome-build
+        uses: esphome/build-action@v7
+        with:
+          yaml-file: ${{ env.ESPHOME_CONFIG }}
+          version: ${{ env.ESPHOME_VERSION }}
+          complete-manifest: true
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.esphome-build.outputs.original-name }}-firmware
+          path: ${{ steps.esphome-build.outputs.name }}


### PR DESCRIPTION
Use the github action whcih runs the build inside a docker container for faster builds. Pin to a fixed version for reproducible builds.

Upload firmware artifact that can be flashed to a device.